### PR TITLE
increasing heatmap raster resolution

### DIFF
--- a/R/heatmap_plot.R
+++ b/R/heatmap_plot.R
@@ -827,6 +827,7 @@ make_copynumber_heatmap <- function(copynumber,
       plotfrequency = plotfrequency, plotcol = plotcol, SV = SV
     ),
     use_raster = TRUE,
+    raster_quality = 10,
     ...
   )
   return(copynumber_hm)


### PR DESCRIPTION
At some point ComplexHeatmap updated how they rasterize heatmaps and this fix makes the heatmaps go from this:
<img width="859" alt="image" src="https://user-images.githubusercontent.com/381464/132925053-035e768d-da60-4b22-9d05-4bec53418af1.png">

to this:
<img width="859" alt="image" src="https://user-images.githubusercontent.com/381464/132925118-f2a4e1df-e58c-41e6-981a-5047b044752e.png">
