### PR TITLE
R-CMD-CHECK workflow installs pandoc

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,6 +22,8 @@ jobs:
       - uses: r-lib/actions/setup-r@v1
       - name: Install xquartz
         run: brew install --cask xquartz
+      - name: Install pandoc
+        run: brew install pandoc
       - name: Install dependencies
         run: |
           install.packages(c("remotes", "rcmdcheck"))


### PR DESCRIPTION
R-CMD-CHECK workflow is throwing up errors on my other pull request due to pandoc not being available. Hopefully this fixes that.